### PR TITLE
Bump Python 3.7 to 3.11

### DIFF
--- a/cftemplates/snapshots_tool_aurora_dest.json
+++ b/cftemplates/snapshots_tool_aurora_dest.json
@@ -410,7 +410,7 @@
 				"Role": {
 					"Fn::GetAtt": ["iamroleSnapshotsAurora", "Arn"]
 				},
-				"Runtime": "python3.7",
+				"Runtime": "python3.11",
 				"Handler": "lambda_function.lambda_handler",
 				"Timeout": 300
 			}
@@ -454,7 +454,7 @@
 				"Role": {
 					"Fn::GetAtt": ["iamroleSnapshotsAurora", "Arn"]
 				},
-				"Runtime": "python3.7",
+				"Runtime": "python3.11",
 				"Handler": "lambda_function.lambda_handler",
 				"Timeout": 300
 			}

--- a/cftemplates/snapshots_tool_aurora_source.json
+++ b/cftemplates/snapshots_tool_aurora_source.json
@@ -433,7 +433,7 @@
 						"Arn"
 					]
 				},
-				"Runtime": "python3.7",
+				"Runtime": "python3.11",
 				"Handler": "lambda_function.lambda_handler",
 				"Timeout": 300
 			}
@@ -475,7 +475,7 @@
 				"Role": {
 					"Fn::GetAtt": ["iamroleSnapshotsAurora", "Arn"]
 				},
-				"Runtime": "python3.7",
+				"Runtime": "python3.11",
 				"Handler": "lambda_function.lambda_handler",
 				"Timeout": 300
 			}
@@ -517,7 +517,7 @@
 				"Role": {
 					"Fn::GetAtt": ["iamroleSnapshotsAurora", "Arn"]
 				},
-				"Runtime": "python3.7",
+				"Runtime": "python3.11",
 				"Handler": "lambda_function.lambda_handler",
 				"Timeout": 300
 			}


### PR DESCRIPTION
AWS plans to deprecate Python 3.7 lambda runtimes by 2023/11/27. More details: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html